### PR TITLE
FIX: Update category in shopList

### DIFF
--- a/src/hooks/useAddItemToShopList.tsx
+++ b/src/hooks/useAddItemToShopList.tsx
@@ -75,6 +75,7 @@ const useAddItemToShopList = () => {
                 // Push to new items array
                 newItems.push({
                     category: categoryName,
+                    category_id: currentItem.category_id,
                     items: [currentItem],
                 })
             }


### PR DESCRIPTION
I detected a bug while reviewing your last pull request.

When adding an item with a category not present in the shopping list, if we try to update the category, it will not be reflected in the shopping list.