### PR TITLE
FIX: Fix the delay issue when clicking on an item to open the ShowItemSidebar

### DIFF
--- a/src/pages/items/ItemsPage.tsx
+++ b/src/pages/items/ItemsPage.tsx
@@ -56,7 +56,7 @@ const ItemsPage: React.FC = () => {
     )
     const setShopList = useSetRecoilState(shopListState)
     const [filteredItems, setFilteredItems] = useState([])
-    const [currentItem, setCurrentItem] = useRecoilState(currentItemState)
+    const setCurrentItem = useSetRecoilState(currentItemState)
     const setSidebarType = useSetRecoilState(sidebarState)
 
     useEffect(() => {
@@ -100,6 +100,7 @@ const ItemsPage: React.FC = () => {
                 ...newLists[index],
                 items: newItems,
                 category: cat.name,
+                category_id: cat.id,
             }
             console.log('newLists', newLists)
             return newLists
@@ -120,11 +121,9 @@ const ItemsPage: React.FC = () => {
         })
 
         // Update the categoryName on the currentItem
-        if (currentItem) {
-            setCurrentItem((old) => {
-                return { ...old, categoryName: cat.name }
-            })
-        }
+        setCurrentItem((old) => {
+            return old !== null ? { ...old, categoryName: cat.name } : old
+        })
     }
 
     /**


### PR DESCRIPTION
This fix removes the delay when showing the ShowItemSidebar.
It's only a little part of the problem I think...

I am not sure why, but the fact to get the currentItemValue from the recoil state can have been called for every item? Which is why the lag happened?