### PR TITLE
Add empty stats and loading state and fix an issue with the category

### DIFF
--- a/src/components/form-elements/CategorySelect.tsx
+++ b/src/components/form-elements/CategorySelect.tsx
@@ -48,11 +48,17 @@ const CategorySelect = ({ label, ...props }: any) => {
     }, [currentItem])
 
     useEffect(() => {
-        const catNameUpToDate: any = categories.find((cat: any) => {
-            return cat.id === currentItem?.category_id
-        })
+        let catNameUpToDate
+        if (currentItem?.category_id) {
+            const category = categories.find((cat: any) => {
+                return cat.id === currentItem?.category_id
+            })
+            catNameUpToDate = category.name
+        } else {
+            catNameUpToDate = currentItem?.categoryName
+        }
 
-        helpers.setValue(catNameUpToDate?.name || '', true)
+        helpers.setValue(catNameUpToDate || '', true)
         helpers.setTouched(true, true)
     }, [currentItem])
 

--- a/src/components/stats/StatsChart.tsx
+++ b/src/components/stats/StatsChart.tsx
@@ -57,7 +57,7 @@ const StatsChart: React.FC<StatsChartProps> = ({
                 margin={{
                     top: 5,
                     right: 30,
-                    left: -35,
+                    left: -15,
                     bottom: 5,
                 }}
             >

--- a/src/pages/statistics/StatisticsPage.tsx
+++ b/src/pages/statistics/StatisticsPage.tsx
@@ -3,6 +3,7 @@ import { useRecoilState } from 'recoil'
 import client from '../../api/client'
 import Button from '../../components/button/Button'
 import Heading from '../../components/heading/Heading'
+import BasicLoader from '../../components/loader/BasicLoader'
 import StatsChart from '../../components/stats/StatsChart'
 import StatsListing from '../../components/stats/StatsListing'
 import { statisticsState } from '../../global-state/statisticsState'
@@ -13,20 +14,47 @@ import { statisticsState } from '../../global-state/statisticsState'
 const StatisticsPage: React.FC = () => {
     const [stats, setStats] = useRecoilState(statisticsState)
     const [interval, setTimeInterval] = useState('month')
+    const [loading, setLoading] = useState(true)
+    const [noStats, setNoStats] = useState(false)
 
     const fetchStats = useCallback(async () => {
         try {
             const res = await client.get('stats')
+            console.log('res', res.status)
             console.log('response', res.data.data)
-            setStats(res.data.data)
+            if (res.status !== 204) {
+                setStats(res.data.data)
+            } else {
+                setNoStats(true)
+            }
         } catch (e) {
             console.log('Error while fetching stats', e)
+        } finally {
+            setLoading(false)
         }
     }, [])
 
     useEffect(() => {
         fetchStats()
     }, [])
+
+    if (loading) {
+        return (
+            <div className="w-full h-screen">
+                <BasicLoader />
+            </div>
+        )
+    }
+
+    if (!loading && noStats) {
+        return (
+            <div className="flex w-full justify-center pt-10">
+                <Heading level={3} className="font-bold">
+                    No statistics to display!
+                </Heading>
+            </div>
+        )
+    }
 
     return (
         <div className="p-4 md:p-6">


### PR DESCRIPTION
- Add a loading state to the statistics page
- Handle the case when the user is just created and doesn't have any stats ( returning a 204 from the backend )
- Fix a little padding issue with the graph when the label on the Y axis are too big
- Fix a little issue with the categorySelect when we add an item to a category for the first time.